### PR TITLE
drinking scenes with chad and jess fixed. changed code formatting in …

### DIFF
--- a/Assets/CutScene/Chad/chad_repeat_t0RF.txt
+++ b/Assets/CutScene/Chad/chad_repeat_t0RF.txt
@@ -2,4 +2,4 @@
 [Newln]Drinking?
 [Newln]I can say for sure that’s better than dancing.
 [Newln]If you’re paying I’ll have a few.
-[Newln]*You spend time drinking with Chad.*[RaiseChadLove1][RaiseChadIntox1][RaisePlayerintox1]
+[Newln]*You spend time drinking with Chad.*[RaiseChadLove1][RaiseChadIntox1][RaisePlayerIntox1]

--- a/Assets/CutScene/Jess/Jess_t_Drepeat0RF.txt
+++ b/Assets/CutScene/Jess/Jess_t_Drepeat0RF.txt
@@ -3,4 +3,4 @@
 [Newln]You want to buy me drinks?
 [Jess2]
 [Newln]Sure, saves me the trouble.
-[Newln]*You spend time drinking with Jessica.* [RaiseJessLove1][RaiseJessIntox1][RaisePlayerintox1]
+[Newln]*You spend time drinking with Jessica.* [RaiseJessLove1][RaiseJessIntox1][RaisePlayerIntox1]

--- a/Assets/ScriptableObjectScripts/Partner.cs
+++ b/Assets/ScriptableObjectScripts/Partner.cs
@@ -71,17 +71,14 @@ public class Partner : ScriptableObject {
         }
     }
 
-    public void __resetValues()
-    {
-        Love = 0;
-        Intoxication = 0;
-        Composure = 0;
+    public void __resetValues() {
+        Love = 0; Intoxication = 0; Composure = 0;
+
         for (int i = 0; i < RelatedCutScenes.Length; i++)
             RelatedCutScenes[i].completed = false;
     }
 
-    public void __resetValues(float love, float intox, float compose)
-    {
+    public void __resetValues(float love, float intox, float compose) {
         Love = love;
         Intoxication = intox;
         Composure = compose;

--- a/Assets/Scripts/AttributeUpdate.cs
+++ b/Assets/Scripts/AttributeUpdate.cs
@@ -21,20 +21,15 @@ public class AttributeUpdate : MonoBehaviour {
     private float transformMuliplier;
     public Queue<info> info = new();
 
-    public void Start()
-    {
+    public void Start() {
         inst = this;
         AttributePopUp.position = OriginalPosition.position;
         transformMuliplier = MathF.Abs(PopUpPosition.position.y - OriginalPosition.position.y);
     }
 
-    public void ShowUI() {
-        FadeIn = true;
-    }
+    public void ShowUI() { FadeIn = true; }
 
-    public void HideUI() {
-        FadeOut = true;
-    }
+    public void HideUI() { FadeOut = true; }
 
     private void Update() {
         if(FadeIn)
@@ -55,13 +50,10 @@ public class AttributeUpdate : MonoBehaviour {
                     FadeOut = false;
                     InView = false;
 
-
-                    if (info.Count > 0)
-                    {
+                    if (info.Count > 0) {
                         UpdateAttribute(info.Peek().stat, info.Peek().change);
                         info.Dequeue();
                     }
-                  
                 }
             }
 
@@ -70,20 +62,14 @@ public class AttributeUpdate : MonoBehaviour {
     }
 
     public void UpdateAttribute(string attribute, int value) {
-        if(FadeIn || FadeOut || InView)
-        {
-            info t = new info();
-            t.stat = attribute;
-            t.change = value;
+        if(FadeIn || FadeOut || InView) {
+            info t = new info { stat = attribute, change = value };
             info.Enqueue(t);
             return;
         }
             
-
         PopUpTextUI.text = "";
-        //PopUpTextUI.text += char.ToUpper(attribute[0]);
         PopUpTextUI.text += attribute + " has been ";
-
         PopUpTextUI.text += (value > 0) ? "increased by " : "decreased by ";
         PopUpTextUI.text += Mathf.Abs(value);
 
@@ -91,10 +77,8 @@ public class AttributeUpdate : MonoBehaviour {
         ShowUI();
     }
 
-    string AttributeName(PlayerSkills skill)
-    {
-        switch (skill)
-        {
+    string AttributeName(PlayerSkills skill) {
+        switch (skill) {
             case PlayerSkills.Intoxication:
                 return "intoxication";
             case PlayerSkills.Skill:
@@ -105,28 +89,23 @@ public class AttributeUpdate : MonoBehaviour {
         return null;
     }
 
-    public void UpdateAttribute(PlayerSkills skill, int value)
-    {
-            UpdateAttribute(AttributeName(skill), value);
-    }
+    public void UpdateAttribute(PlayerSkills skill, int value) { UpdateAttribute(AttributeName(skill), value); }
 
     public void UpdateAttributeButton(string String) {
         string AttributeString = String.Substring(1, String.Length - 1);
         char c = String[String.Length - 1];
         int AttributeValue = int.Parse(c.ToString());
 
-        if (String[0].Equals('+'))
-            UpdateAttribute(AttributeString, AttributeValue);
-        else
-            UpdateAttribute(AttributeString, AttributeValue * -1);
+        if (!String[0].Equals('+'))
+            AttributeValue *= -1;
 
+        UpdateAttribute(AttributeString, AttributeValue);
     }
 
     
 }
 
-public class info
-{
+public class info {
     public string stat;
     public int change;
 }

--- a/Assets/Scripts/CussceneScripts/CutScene.cs
+++ b/Assets/Scripts/CussceneScripts/CutScene.cs
@@ -196,12 +196,11 @@ public class CutScene : ScriptableObject
                     return PCS;
                 }
             case __CutsceneActions.ResetIntox:
-               
-                    ChangeStat PCSee = new ChangeStat();
-                    PCSee.Character = __getCharactersFrom(ss);
-                    PCSee.Stat = __GetSkill(ss);
-                    PCSee.Adjust = -1000000;
-                    return PCSee;
+                ChangeStat PCSee = new ChangeStat();
+                PCSee.Character = __getCharactersFrom(ss);
+                PCSee.Stat = __GetSkill(ss);
+                PCSee.Adjust = -1000000;
+                return PCSee;
 
         }
         return null;

--- a/Assets/Scripts/Schedule.cs
+++ b/Assets/Scripts/Schedule.cs
@@ -52,7 +52,9 @@ public class Schedule : MonoBehaviour
 
     private string timeAsString()
     {
-        return hour + ":" + (minutes==0?"00":minutes.ToString()) + "PM";
+        string minutesString = (minutes < 10) ? "0" : "";
+        minutesString += minutes.ToString();
+        return hour + ":" + minutesString + "PM";
     }
 
     public void click()


### PR DESCRIPTION
**Changes**
- Block values for player intoxication increases was previously set to null and manually reset
- Reformatted a few lines of code; specifically the curly brackets
  - Didn't to all lines, in fear of merge conflicts because unity and github like to fight
- Character drinking repeat scenes (specifically chad and jess), the camelcase in the flags for player intoxication were fixed
- Time display logic was changed to hopefully display time correctly when minutes are in the single digits (NOT TESTED)
  - EX: 8 hours, 5 minutes would appear as 8:5PM when it should appear as 8:05PM